### PR TITLE
surround file path with with backticks instead of single quotes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Data from default section uses until it's overridden in specific environment.
 
 ### ERB support
 
-Config file 'global/file_name.yml' with:
+Config file `global/file_name.yml` with:
 
 ```yml
 test:


### PR DESCRIPTION
Very minor edit to README to make style treatment of file paths consistent.

Thanks for sharing your code!
