### PR TITLE
Delegates has_key?, include? and member? to Hash

### DIFF
--- a/lib/global/configuration.rb
+++ b/lib/global/configuration.rb
@@ -8,7 +8,7 @@ module Global
 
     attr_reader :hash
 
-    def_delegators :hash, :key?, :[], :[]=, :to_hash, :to_json, :inspect
+    def_delegators :hash, :key?, :has_key?, :include?, :member?, :[], :[]=, :to_hash, :to_json, :inspect
 
 
     def initialize(hash)

--- a/spec/global/configuration_spec.rb
+++ b/spec/global/configuration_spec.rb
@@ -22,6 +22,24 @@ RSpec.describe Global::Configuration do
     it{ is_expected.to be_truthy }
   end
 
+  describe "has_key?" do
+    subject{ configuration.has_key?(:key) }
+
+    it{ is_expected.to be_truthy }
+  end
+
+  describe "include?" do
+    subject{ configuration.include?(:key) }
+
+    it{ is_expected.to be_truthy }
+  end
+
+  describe "member?" do
+    subject{ configuration.member?(:key) }
+
+    it{ is_expected.to be_truthy }
+  end
+
   describe "#[]" do
     subject{ configuration[:key] }
 


### PR DESCRIPTION
`Hash#has_key?` , `Hash#include?` and `Hash#member?` are alias of `Hash#key?`

So I thought it was convenient to delegate these as well as `#key?`