### PR TITLE
Fixed: rails(api-mode) crashed in starting

### DIFF
--- a/lib/global/engine.rb
+++ b/lib/global/engine.rb
@@ -61,7 +61,7 @@ module Global
             "application/javascript",
             SprocketsExtension
           )
-        else
+        elsif Rails.application.config.respond_to?(:assets)
           # Other rails version, assumed newer
           Rails.application.config.assets.configure do |config|
             config.register_preprocessor(


### PR DESCRIPTION
When using global with Rails api mode, crashed in starting

This is regression of #20

api mode doesn't have `Rails.application.config.assets`

```
$ ./bin/rails s

rails aborted!
NoMethodError: undefined method `assets' for #<Rails::Application::Configuration:0x007f92c8731ee8>
Did you mean?  asset_host
/app/config/environment.rb:5:in `<top (required)>'
bin/rails:4:in `require'
bin/rails:4:in `<main>'
```