### PR TITLE
Added whitelist_classes functionality in order to be able to whitelist your own classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ gem 'global'
 ```ruby
 > Global.environment = "YOUR_ENV_HERE"
 > Global.config_directory = "PATH_TO_DIRECTORY_WITH_FILES"
+> Global.yaml_whitelist_classes = [] # optional configuration
 ```
 
 Or you can use `configure` block:
@@ -23,6 +24,7 @@ Or you can use `configure` block:
 Global.configure do |config|
   config.environment = "YOUR_ENV_HERE"
   config.config_directory = "PATH_TO_DIRECTORY_WITH_FILES"
+  config.yaml_whitelist_classes = [] # optional configuration
 end
 ```
 
@@ -32,8 +34,11 @@ For rails put initialization into `config/initializers/global.rb`
 Global.configure do |config|
   config.environment = Rails.env.to_s
   config.config_directory = Rails.root.join('config/global').to_s
+  config.yaml_whitelist_classes = [] # optional configuration
 end
 ```
+
+The `yaml_whitelist_classes` configuration allows you to deserialize other classes from your `.yml`
 
 ## Usage
 
@@ -60,6 +65,23 @@ In the development environment we now have:
 => { "api" => "api.localhost", "web" => "localhost" }
 > Global.hosts.api
 => "api.localhost"
+```
+
+#### Deserialize other classes from `.yml`
+
+Config file `config/global/validations.yml`:
+
+```yml
+default:
+  regexp:
+    email: !ruby/regexp /.@.+\../
+```
+
+Ensure that `Regexp` is included in the `yaml_whitelist_classes` array
+
+```ruby
+Global.validations.regexp.email === 'mail@example.com'
+=> true
 ```
 
 ### Namespacing

--- a/lib/global/base.rb
+++ b/lib/global/base.rb
@@ -11,7 +11,7 @@ module Global
 
     extend self
 
-    attr_writer :environment, :config_directory, :namespace, :except, :only
+    attr_writer :environment, :config_directory, :namespace, :except, :only, :whitelist_classes
 
     def configure
       yield self
@@ -44,6 +44,10 @@ module Global
 
     def only
       @only ||= []
+    end
+
+    def whitelist_classes
+      @whitelist_classes ||= []
     end
 
     def generate_js(options = {})
@@ -83,7 +87,8 @@ module Global
     def load_yml_file(file)
       YAML.safe_load(
         ERB.new(IO.read(file)).result,
-        [Date, Time, DateTime, Symbol], [], true
+        [Date, Time, DateTime, Symbol].concat(whitelist_classes),
+        [], true
       )
     end
 

--- a/lib/global/base.rb
+++ b/lib/global/base.rb
@@ -11,7 +11,7 @@ module Global
 
     extend self
 
-    attr_writer :environment, :config_directory, :namespace, :except, :only, :whitelist_classes
+    attr_writer :environment, :config_directory, :namespace, :except, :only, :yaml_whitelist_classes
 
     def configure
       yield self
@@ -46,8 +46,8 @@ module Global
       @only ||= []
     end
 
-    def whitelist_classes
-      @whitelist_classes ||= []
+    def yaml_whitelist_classes
+      @yaml_whitelist_classes ||= []
     end
 
     def generate_js(options = {})
@@ -87,7 +87,7 @@ module Global
     def load_yml_file(file)
       YAML.safe_load(
         ERB.new(IO.read(file)).result,
-        [Date, Time, DateTime, Symbol].concat(whitelist_classes),
+        [Date, Time, DateTime, Symbol].concat(yaml_whitelist_classes),
         [], true
       )
     end


### PR DESCRIPTION
I was having problem to store Regexp in the .yml
After doing this dev, I was able to add the Regexp class to the whitelisted classes
Hence easily and practically save Regexp in the .yml