### PR TITLE
Fix NameError when using global alone

### DIFF
--- a/lib/global.rb
+++ b/lib/global.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'date'
 require 'yaml'
 
 require 'active_support/core_ext/hash/indifferent_access'


### PR DESCRIPTION
`NameError` occurs when loading yaml. ([`Global::Base#load_yml_file`](https://github.com/railsware/global/blob/master/lib/global/base.rb#L88-L92))
The Date class specified in whitelist_classes of `YAML.safe_load` is not loaded

```
$ irb
irb(main):001:0> require "bundler/setup"
=> true
irb(main):002:0> require "global"
=> true
irb(main):003:0> Global.configure do |config|
irb(main):004:1*   config.environment = "local"
irb(main):005:1>   config.config_directory = "config/global"
irb(main):006:1> end
=> "config/global"
irb(main):007:0> Global.app.foo
Traceback (most recent call last):
       13: from .rbenv/versions/2.6.3/bin/irb:23:in `<main>'
       12: from .rbenv/versions/2.6.3/bin/irb:23:in `load'
       11: from .rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
       10: from (irb):7
        9: from app/.bundle/ruby/2.6.0/gems/global-1.1.0/lib/global/base.rb:115:in `method_missing'
        8: from app/.bundle/ruby/2.6.0/gems/global-1.1.0/lib/global/base.rb:21:in `configuration'
        7: from app/.bundle/ruby/2.6.0/gems/global-1.1.0/lib/global/base.rb:64:in `load_configuration'
        6: from app/.bundle/ruby/2.6.0/gems/global-1.1.0/lib/global/base.rb:99:in `load_from_directory'
        5: from app/.bundle/ruby/2.6.0/gems/global-1.1.0/lib/global/base.rb:99:in `each'
        4: from app/.bundle/ruby/2.6.0/gems/global-1.1.0/lib/global/base.rb:103:in `block in load_from_directory'
        3: from app/.bundle/ruby/2.6.0/gems/global-1.1.0/lib/global/base.rb:63:in `load_configuration'
        2: from app/.bundle/ruby/2.6.0/gems/global-1.1.0/lib/global/base.rb:72:in `load_from_file'
        1: from app/.bundle/ruby/2.6.0/gems/global-1.1.0/lib/global/base.rb:90:in `load_yml_file'
NameError (uninitialized constant Global::Base::Date)
Did you mean?  Data
irb(main):008:0> require "date"
=> true
irb(main):009:0> Global.app.foo
=> 1
```