### PR TITLE
Fix rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -48,7 +48,7 @@ Style/RegexpLiteral:
   EnforcedStyle: slashes
   AllowInnerSlashes: false
 
-Layout/IndentHash:
+Layout/IndentFirstHashElement:
   EnforcedStyle: consistent
 
 Style/Documentation:


### PR DESCRIPTION
Fix the following an error.

```
$ bundle exec rubocop
Error: The `Layout/IndentHash` cop has been renamed to `Layout/IndentFirstHashElement`.
(obsolete configuration found in .rubocop.yml, please update it)
```