### PR TITLE
Pluggable backends. AWS Parameter Store backend implementation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -78,29 +78,29 @@ Style/SafeNavigation:
 
 Lint/AmbiguousBlockAssociation:
   Exclude:
-    - 'spec/**/*'
+    - "spec/**/*"
 
 Naming/PredicateName:
   Exclude:
-    - 'spec/**/*'
+    - "spec/**/*"
 
 Style/NumericPredicate:
   Exclude:
-    - 'spec/**/*'
+    - "spec/**/*"
 
 Metrics/BlockLength:
   Exclude:
-    - 'spec/**/*'
+    - "spec/**/*"
 
 Metrics/LineLength:
   Max: 120
   Exclude:
-    - 'spec/**/*'
+    - "spec/**/*"
 
 Metrics/AbcSize:
   Max: 22
   Exclude:
-    - 'spec/**/*'
+    - "spec/**/*"
 
 Style/ModuleFunction:
   EnforcedStyle: extend_self

--- a/README.md
+++ b/README.md
@@ -271,11 +271,13 @@ will be merged.
 > Global.reload!
 ```
 
-## Rails Webpacker usage
+## Using YAML configuration files with Rails Webpacker
 
-Add in `package.json` file `js-yaml` npm package (use command `yarn add js-yaml`).
+If you use the `:filesystem` backend, you can reuse the same configuration files on the frontend:
 
-Next create file `config/webpacker/global/index.js` with content:
+Add [js-yaml](https://www.npmjs.com/package/js-yaml) npm package to `package.json` (use command `yarn add js-yaml`).
+
+Then create a file at `config/webpacker/global/index.js` with the following:
 
 ```js
 const yaml = require('js-yaml')
@@ -317,7 +319,7 @@ module.exports = {
 }
 ```
 
-After this modify file `config/webpacker/environment.js`:
+After this, modify file `config/webpacker/environment.js`:
 
 ```js
 const path = require('path')
@@ -342,7 +344,7 @@ environment.plugins.prepend('Environment', new webpack.EnvironmentPlugin({
 module.exports = environment
 ```
 
-Now you can use this variable in you code:
+Now you can use these `process.env` keys in your code:
 
 ```js
 import {init} from '@sentry/browser'

--- a/README.md
+++ b/README.md
@@ -32,6 +32,20 @@ Global.configure do |config|
 end
 ```
 
+You can declare as many backends as you want; the configuration trees from the backends are deep-merged together,
+so that the backend declared later overwrites specific keys in the backend declared prior:
+
+```ruby
+Global.configure do |config|
+  config.backend :foo # loads tree { credentials: { hostname: 'api.com', username: 'dev', password: 'dev' } }
+  config.backend :bar # loads tree { credentials: { username: 'xxx', password: 'yyy' } }
+end
+
+Global.credentials.hostname # => 'api.com'
+Global.credentials.username # => 'xxx'
+Global.credentials.password # => 'yyy'
+```
+
 For Rails, put initialization into `config/initializers/global.rb`.
 
 There are some sensible defaults, check your backend class for documentation.

--- a/global.gemspec
+++ b/global.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec',     '>= 3.0'
   s.add_development_dependency 'rubocop',   '~> 0.81.0'
   s.add_development_dependency 'simplecov', '~> 0.16.1'
+  s.add_development_dependency 'aws-sdk-ssm', '~> 1'
 
   s.add_runtime_dependency 'activesupport', '>= 2.0'
 end

--- a/lib/global/backend/aws_parameter_store.rb
+++ b/lib/global/backend/aws_parameter_store.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+module Global
+  module Backend
+    # Loads Global configuration from the AWS Systems Manager Parameter Store
+    # https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html
+    #
+    # This backend requires the `aws-sdk` or `aws-sdk-ssm` gem, so make sure to add it to your Gemfile.
+    #
+    # Available options:
+    # - `prefix` (required): the prefix in Parameter Store; all parameters within the prefix will be loaded;
+    #   make sure to add a trailing slash, if you want it
+    #   see https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-paramstore-su-organize.html
+    # - `client`: pass you own Aws::SSM::Client instance, or alternatively set:
+    # - `aws_options`: credentials and other AWS configuration options that are passed to AWS::SSM::Client.new
+    #   see https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/SSM/Client.html#initialize-instance_method
+    #   If AWS access is already configured through environment variables,
+    #   you don't need to pass the credentials explicitly.
+    #
+    # For Rails:
+    # - the `prefix` is optional and defaults to `/[Rails enviroment]/[Name of the app class]/`,
+    #    for example: `/production/MyApp/`
+    # - to use a different app name, pass `app_name`,
+    #    for example: `backend :aws_parameter_store, app_name: 'new_name_for_my_app'`
+    class AwsParameterStore
+
+      PATH_SEPARATOR = '/'
+
+      def initialize(options = {})
+        require_aws_gem
+        init_prefix(options)
+        init_client(options)
+      end
+
+      def load
+        build_configuration_from_parameters(load_all_parameters_from_ssm)
+      end
+
+      private
+
+      def require_aws_gem
+        require 'aws-sdk-ssm'
+      rescue LoadError
+        begin
+          require 'aws-sdk'
+        rescue LoadError
+          raise 'Either the `aws-sdk-ssm` or `aws-sdk` gem must be installed.'
+        end
+      end
+
+      def init_prefix(options)
+        if defined?(Rails)
+          environment = Rails.env.to_s
+          @prefix = options.fetch(:prefix) do
+            app_name = options.fetch(:app_name) { Rails.application.class.module_parent_name }
+            "/#{environment}/#{app_name}/"
+          end
+        else
+          @prefix = options.fetch(:prefix)
+        end
+      end
+
+      def init_client(options)
+        if options.key?(:client)
+          @ssm = options[:client]
+        else
+          aws_options = options.fetch(:aws_options, {})
+          @ssm = Aws::SSM::Client.new(aws_options)
+        end
+      end
+
+      def load_all_parameters_from_ssm
+        response = load_parameters_from_ssm
+        all_parameters = response.parameters
+        loop do
+          break unless response.next_token
+
+          response = load_parameters_from_ssm(response.next_token)
+          all_parameters.concat(response.parameters)
+        end
+
+        all_parameters
+      end
+
+      def load_parameters_from_ssm(next_token = nil)
+        @ssm.get_parameters_by_path(
+          path: @prefix,
+          recursive: true,
+          with_decryption: true,
+          next_token: next_token
+        )
+      end
+
+      # builds a nested configuration hash from the array of parameters from SSM
+      def build_configuration_from_parameters(parameters)
+        configuration = {}
+        parameters.each do |parameter|
+          parameter_parts = parameter.name[@prefix.length..-1].split(PATH_SEPARATOR).map(&:to_sym)
+          param_container = parameter_parts[0..-2].reduce(configuration) do |container, part|
+            container[part] ||= {}
+          end
+          param_container[parameter_parts[-1]] = parameter.value
+        end
+
+        configuration
+      end
+
+    end
+  end
+end

--- a/lib/global/backend/filesystem.rb
+++ b/lib/global/backend/filesystem.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+module Global
+  module Backend
+    # Loads Global configuration from the filesystem
+    #
+    # Available options:
+    # - `directory` (required): the directory with config files
+    # - `environment` (required): the environment to load
+    # - `yaml_whitelist_classes`: the set of classes that are permitted to unmarshal from the configuration files
+    #
+    # For Rails:
+    # - the `directory` is optional and defaults to `config/global`
+    # - the `environment` is optional and defaults to the current Rails environment
+    class Filesystem
+
+      FILE_ENV_SPLIT = '.'
+      YAML_EXT = '.yml'
+
+      def initialize(options = {})
+        if defined?(Rails)
+          @path = options.fetch(:path) { Rails.root.join('config', 'global').to_s }
+          @environment = options.fetch(:environment) { Rails.env.to_s }
+        else
+          @path = options.fetch(:path)
+          @environment = options.fetch(:environment)
+        end
+        @yaml_whitelist_classes = options.fetch(:yaml_whitelist_classes, [])
+      end
+
+      def load
+        load_from_path(@path)
+      end
+
+      private
+
+      def load_from_path(path)
+        load_from_file(path).deep_merge(load_from_directory(path))
+      end
+
+      def load_from_file(path)
+        config = {}
+
+        if File.exist?(file = "#{path}#{YAML_EXT}")
+          configurations = load_yml_file(file)
+          config = get_config_by_key(configurations, 'default')
+          config.deep_merge!(get_config_by_key(configurations, @environment))
+          if File.exist?(env_file = "#{path}#{FILE_ENV_SPLIT}#{@environment}#{YAML_EXT}")
+            config.deep_merge!(load_yml_file(env_file) || {})
+          end
+        end
+
+        config
+      end
+
+      def get_config_by_key(config, key)
+        return {} if config.empty?
+
+        config[key.to_sym] || config[key.to_s] || {}
+      end
+
+      def load_yml_file(file)
+        YAML.safe_load(
+          ERB.new(IO.read(file)).result,
+          [Date, Time, DateTime, Symbol].concat(@yaml_whitelist_classes),
+          [], true
+        )
+      end
+
+      def load_from_directory(path)
+        config = {}
+
+        if File.directory?(path)
+          Dir["#{path}/*"].each do |entry|
+            namespace = File.basename(entry, YAML_EXT)
+            next if namespace.include? FILE_ENV_SPLIT # skip files with dot(s) in name
+
+            file_with_path = File.join(File.dirname(entry), File.basename(entry, YAML_EXT))
+            config.deep_merge!(namespace => load_from_path(file_with_path))
+          end
+        end
+
+        config
+      end
+
+    end
+  end
+end

--- a/lib/global/base.rb
+++ b/lib/global/base.rb
@@ -16,7 +16,9 @@ module Global
       raise 'Backend must be defined' unless @backends
 
       @configuration ||= begin
-        configuration_hash = @backends.reduce({}) { |configuration, backend| configuration.deep_merge(backend.load) }
+        configuration_hash = @backends.reduce({}) do |configuration, backend|
+          configuration.deep_merge(backend.load.with_indifferent_access)
+        end
         Configuration.new(configuration_hash)
       end
     end

--- a/lib/global/base.rb
+++ b/lib/global/base.rb
@@ -59,9 +59,7 @@ module Global
     end
 
     def method_missing(method, *args, &block)
-      configuration.send(method)
-    rescue NoMethodError
-      super
+      configuration.key?(method) ? configuration.get_configuration_value(method) : super
     end
 
     # from Bundler::Thor::Util.camel_case

--- a/lib/global/configuration.rb
+++ b/lib/global/configuration.rb
@@ -22,6 +22,13 @@ module Global
       hash.select { |key, _| keys.include?(key) }
     end
 
+    def get_configuration_value(key)
+      return nil unless key?(key)
+
+      value = hash[key]
+      value.is_a?(Hash) ? Global::Configuration.new(value) : value
+    end
+
     private
 
     def filtered_keys_list(options)
@@ -44,8 +51,7 @@ module Global
     def method_missing(method, *args, &block)
       method = normalize_key_by_method(method)
       if key?(method)
-        value = hash[method]
-        value.is_a?(Hash) ? Global::Configuration.new(value) : value
+        get_configuration_value(method)
       else
         super
       end

--- a/spec/global/backend/aws_parameter_store_spec.rb
+++ b/spec/global/backend/aws_parameter_store_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'aws-sdk-ssm'
+require 'global/backend/aws_parameter_store'
+
+RSpec.describe Global::Backend::AwsParameterStore do
+  let(:client) do
+    Aws::SSM::Client.new(stub_responses: true)
+  end
+  subject do
+    described_class.new(prefix: '/testapp/', client: client)
+  end
+
+  it 'reads parameters from the parameter store' do
+    client.stub_responses(
+      :get_parameters_by_path,
+      [
+        lambda { |req_context|
+          expect(req_context.params[:next_token]).to be_nil
+          {
+            parameters: [
+              { name: '/testapp/foo', value: 'foo-value' },
+              { name: '/testapp/bar/baz', value: 'baz-value' }
+            ],
+            next_token: 'next-token'
+          }
+        },
+        lambda { |req_context|
+          expect(req_context.params[:next_token]).to eq('next-token')
+          {
+            parameters: [
+              { name: '/testapp/bar/qux', value: 'qux-value' }
+            ],
+            next_token: nil
+          }
+        }
+      ]
+    )
+    expect(subject.load).to eq(
+      foo: 'foo-value',
+      bar: {
+        baz: 'baz-value',
+        qux: 'qux-value'
+      }
+    )
+  end
+end

--- a/spec/global_spec.rb
+++ b/spec/global_spec.rb
@@ -4,34 +4,10 @@ require 'spec_helper'
 
 RSpec.describe Global do
 
+  let(:config_path) { File.join(Dir.pwd, 'spec/files') }
   before(:each) do
     described_class.configure do |config|
-      config.environment = 'test'
-      config.config_directory = File.join(Dir.pwd, 'spec/files')
-    end
-  end
-
-  describe '.environment' do
-    subject { described_class.environment }
-
-    it { is_expected.to eq('test') }
-
-    context 'when undefined' do
-      before { described_class.environment = nil }
-
-      it { expect { subject }.to raise_error('environment should be defined') }
-    end
-  end
-
-  describe '.config_directory' do
-    subject { described_class.config_directory }
-
-    it { is_expected.to eq(File.join(Dir.pwd, 'spec/files')) }
-
-    context 'when undefined' do
-      before { described_class.config_directory = nil }
-
-      it { expect { subject }.to raise_error('config_directory should be defined') }
+      config.backend :filesystem, path: config_path, environment: 'test'
     end
   end
 
@@ -51,10 +27,9 @@ RSpec.describe Global do
     end
 
     context 'when load from file' do
-      before { described_class.config_directory = File.join(Dir.pwd, 'spec/files/rspec_config') }
+      let(:config_path) { File.join(Dir.pwd, 'spec/files/rspec_config') }
 
       describe '#rspec_config' do
-        subject { super().rspec_config }
         describe '#to_hash' do
           subject { super().to_hash }
           it { is_expected.to eq('default_value' => 'default value', 'test_value' => 'test value') }
@@ -88,12 +63,8 @@ RSpec.describe Global do
 
     before do
       described_class.configuration
-      described_class.environment = 'development'
-    end
-
-    after do
-      described_class.environment = 'test'
-      described_class.reload!
+      described_class.instance_variable_set('@backends', [])
+      described_class.backend :filesystem, path: config_path, environment: 'development'
     end
 
     it { is_expected.to be_instance_of(Global::Configuration) }
@@ -141,5 +112,4 @@ RSpec.describe Global do
     end
 
   end
-
 end

--- a/spec/merge_backends_spec.rb
+++ b/spec/merge_backends_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Global do
+  describe 'merging backends' do
+    it 'merges data from two backends together' do
+      backend_alpha = double('backend_alpha')
+      allow(backend_alpha).to receive(:load).and_return(foo: 'foo', bar: 'bar-alpha')
+      described_class.backend backend_alpha
+
+      backend_beta = double('backend1')
+      allow(backend_beta).to receive(:load).and_return(bar: 'bar-beta', baz: 'baz')
+      described_class.backend backend_beta
+
+      expect(described_class.configuration.to_hash).to eq(
+        'foo' => 'foo',
+        'bar' => 'bar-beta',
+        'baz' => 'baz'
+      )
+    end
+  end
+end

--- a/spec/merge_backends_spec.rb
+++ b/spec/merge_backends_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe Global do
       allow(backend_alpha).to receive(:load).and_return(foo: 'foo', bar: 'bar-alpha')
       described_class.backend backend_alpha
 
-      backend_beta = double('backend1')
-      allow(backend_beta).to receive(:load).and_return(bar: 'bar-beta', baz: 'baz')
+      backend_beta = double('backend_beta')
+      allow(backend_beta).to receive(:load).and_return('bar' => 'bar-beta', 'baz' => 'baz')
       described_class.backend backend_beta
 
       expect(described_class.configuration.to_hash).to eq(

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,4 +38,9 @@ RSpec.configure do |config|
   config.filter_run :focus
 
   config.order = 'random'
+
+  config.before do
+    Global.remove_instance_variable(:@backends) if Global.instance_variable_defined?(:@backends)
+    Global.remove_instance_variable(:@configuration) if Global.instance_variable_defined?(:@configuration)
+  end
 end


### PR DESCRIPTION
Let's move into the future with enterprise-grade secrets management!

- The part that loads the config is now called a "backend"
- You can configure one or more backends in the application
- The former backend is called `filesystem`
- There is a new backend called `aws_parameter_store`
- If Rails is detected, sensible defaults are applied (the environment and `config/global` as the path to configuration)

New features in a nutshell:

```ruby
Global.configure do |config|
  config.backend :filesystem
  config.backend :aws_parameter_store, app_name: 'my_killer_app'
end
```

I would like to add two more backends - `environment` to read env variables and `adhoc` to supply a hash in place like 

```
Global.backend :adhoc, { foo: 'bar' }
```

But for now there is only production demand for a ParamStore backend.