### PR TITLE
[doc] Fix description for filesystem backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ Refer to the documentation on your chosen backend class for other dependencies.
 Refer to the documentation on your chosen backend class for configuration options.
 
 ```ruby
-> Global.backend(:filesystem, environment: "YOUR_ENV_HERE", directory: "PATH_TO_DIRECTORY_WITH_FILES")
+> Global.backend(:filesystem, environment: "YOUR_ENV_HERE", path: "PATH_TO_DIRECTORY_WITH_FILES")
 ```
 
 Or you can use `configure` block:
 
 ```ruby
 Global.configure do |config|
-  config.backend :filesystem, environment: "YOUR_ENV_HERE", directory: "PATH_TO_DIRECTORY_WITH_FILES"
+  config.backend :filesystem, environment: "YOUR_ENV_HERE", path: "PATH_TO_DIRECTORY_WITH_FILES"
   # set up multiple backends and have them merged together:
   config.backend :aws_parameter_store, prefix: '/prod/MyApp/'
   config.backend :gcp_secret_manager, prefix: 'prod-myapp-', project_id: 'example'

--- a/lib/global/backend/filesystem.rb
+++ b/lib/global/backend/filesystem.rb
@@ -5,12 +5,12 @@ module Global
     # Loads Global configuration from the filesystem
     #
     # Available options:
-    # - `directory` (required): the directory with config files
+    # - `path` (required): the directory with config files
     # - `environment` (required): the environment to load
     # - `yaml_whitelist_classes`: the set of classes that are permitted to unmarshal from the configuration files
     #
     # For Rails:
-    # - the `directory` is optional and defaults to `config/global`
+    # - the `path` is optional and defaults to `config/global`
     # - the `environment` is optional and defaults to the current Rails environment
     class Filesystem
 

--- a/lib/global/base.rb
+++ b/lib/global/base.rb
@@ -34,7 +34,7 @@ module Global
     # and the configuration hashes will be merged.
     #
     # Configure with either:
-    #   Global.backend :filesystem, directory: 'config', environment: Rails.env
+    #   Global.backend :filesystem, path: 'config', environment: Rails.env
     # or:
     #   Global.backend YourConfigurationBackend.new
     #


### PR DESCRIPTION
# Context
I upgrade to global 2.0.0.

So I fixed as [documented](https://github.com/railsware/global/blob/v2.0.0/README.md#configuration) 

```diff
     Global.configure do |config|
-      config.environment = ENV["RACK_ENV"]
-      config.config_directory = "#{__dir__}/config/global"
+      config.backend :filesystem, environment: ENV["RACK_ENV"], directory: "#{__dir__}/config/global"
     end
```

But error is occurred.

```
2020-04-18 01:38:01 - KeyError - key not found: :path:
      /app/vendor/bundle/ruby/2.7.0/gems/global-2.0.0/lib/global/backend/filesystem.rb:25:in `fetch'
      /app/vendor/bundle/ruby/2.7.0/gems/global-2.0.0/lib/global/backend/filesystem.rb:25:in `initialize'
      /app/vendor/bundle/ruby/2.7.0/gems/global-2.0.0/lib/global/base.rb:47:in `new'
      /app/vendor/bundle/ruby/2.7.0/gems/global-2.0.0/lib/global/base.rb:47:in `backend'
      /app/app.rb:31:in `block (2 levels) in <class:App>'
      /app/vendor/bundle/ruby/2.7.0/gems/global-2.0.0/lib/global/base.rb:12:in `configure'
      /app/app.rb:30:in `block in <class:App>'
```

# Cause
The document says `directory`, but it actually uses `path` in code.

https://github.com/railsware/global/blob/v2.0.0/lib/global/backend/filesystem.rb#L25

So I fixed doc and comment.